### PR TITLE
Fix build with gcc 8.2.1

### DIFF
--- a/src/Libs/EvolutionaryCore/CandidateSelection.h
+++ b/src/Libs/EvolutionaryCore/CandidateSelection.h
@@ -37,6 +37,7 @@
 #include "CandidateSolution.h"
 #include "Random.h"
 
+#include <functional>
 #include <numeric>
 
 // forward declaration

--- a/src/Libs/EvolutionaryCore/Evaluator.h
+++ b/src/Libs/EvolutionaryCore/Evaluator.h
@@ -28,6 +28,7 @@
 #define HEADER_UGP3_CORE_EVALUATOR
 
 
+#include <functional>
 #include <string>
 #include <mutex>
 #include <atomic>


### PR DESCRIPTION
Some headers were missing includes for std::functional. The build also triggers lots of warnings, because of exception specifications, but they are harmless:

```
microgp3/src/Libs/EvolutionaryCore/PopulationParameters.h:511:87: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     static std::unique_ptr<PopulationParameters> instantiate(const std::string& type) throw(std::exception);
                                                                                       ^~~~~
```