### PR TITLE
Fix for compilation with >=4.5 gcc versions

### DIFF
--- a/src/Libs/EvolutionaryCore/CandidateSelection.h
+++ b/src/Libs/EvolutionaryCore/CandidateSelection.h
@@ -38,6 +38,7 @@
 #include "Random.h"
 
 #include <numeric>
+#include <functional>
 
 // forward declaration
 namespace Ui

--- a/src/Libs/EvolutionaryCore/Evaluator.h
+++ b/src/Libs/EvolutionaryCore/Evaluator.h
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
+#include <functional>
 
 #include "XMLIFace.h"
 


### PR DESCRIPTION
Resolved `std::variant` issue during compilation.